### PR TITLE
DEV-4262: Preserving the window.File interface

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -46,7 +46,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     </js-module>
 
     <js-module src="www/File.js" name="File">
-        <clobbers target="window.File" />
+        <clobbers target="window.cordova.File" />
     </js-module>
 
     <js-module src="www/FileEntry.js" name="FileEntry">

--- a/www/FileWriter.js
+++ b/www/FileWriter.js
@@ -23,6 +23,7 @@ var exec = require('cordova/exec');
 var FileError = require('./FileError');
 var FileReader = require('./FileReader');
 var ProgressEvent = require('./ProgressEvent');
+var File = require('./File');
 
 /**
  * This class writes to the mobile device file system.


### PR DESCRIPTION
The `window.File` interface is being overridden by default. 
This leads to some issues due to its incompatibility with the standard interface.